### PR TITLE
Only hyphenate elements that are explicitly listed in the options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,24 +69,15 @@ function plugin(options) {
    * Traverses throught parsed DOM, and hyphenate text nodes
    *
    * @param {String} domString
-   * @param {Boolean} forceHyphenate
    * @return {String}
    */
-  function hyphenateText(dom, forceHyphenate) {
-    if (forceHyphenate === undefined) {
-      forceHyphenate = false;
-    }
-
-    if (isPresent(options.elements, dom.tagName)) {
-      forceHyphenate = true;
-    }
-
+  function hyphenateText(dom) {
     if (dom.childNodes !== undefined) {
       dom.childNodes.forEach(function(node) {
-        if (node.nodeName === '#text' && forceHyphenate) {
+        if (node.nodeName === '#text' && isPresent(options.elements, dom.tagName)) {
           node.value = hypher.hyphenateText(node.value);
         } else {
-          hyphenateText(node, forceHyphenate);
+          hyphenateText(node);
         }
       });
     }

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ describe('metalsmith-hyphenate', function() {
 
   it('should hyphenate with custom settings', function(done) {
     check('custom-settings', metalsmithHyphenate({
-      elements: ['blockquote'],
+      elements: ['blockquote', 'cite'],
       langModule: 'hyphenation.de'
     }), done);
   });


### PR DESCRIPTION
I noticed elements were hyphenated even though I did not list them in the options. This caused some breakage because I expected only the elements I explicitly requested to be hyphenated. This pull request changes the code so that it only hyphenates the specified elements. This is the same way Hypher works.
