### PR TITLE
don't dump the whole document into files

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,9 +120,9 @@ function plugin(options) {
       }
 
       debug('hyphenating "%s"', file);
-      var dom = p5.parse(files[file].contents.toString());
-      dom = hyphenateText(dom);
-      files[file].contents = new Buffer(p5.serialize(dom));
+      var doc = p5.parse(files[file].contents.toString());
+      doc = hyphenateText(dom);
+      files[file].contents = new Buffer(p5.serialize(doc.childNodes[0].childNodes[1]));
     });
   };
 }


### PR DESCRIPTION
parse5 returns a complete document, we only want the DOM within the body of that doc, prior to this fix content in files was incorrectly wrapped with html and body elements.
